### PR TITLE
feat: Print tx creation timestamp on worker side

### DIFF
--- a/benchmark/benchmark/local.py
+++ b/benchmark/benchmark/local.py
@@ -5,49 +5,55 @@ from os.path import basename, splitext
 from time import sleep
 
 from benchmark.commands import CommandMaker
-from benchmark.config import Key, LocalCommittee, NodeParameters, BenchParameters, ConfigError
+from benchmark.config import (
+    Key,
+    LocalCommittee,
+    NodeParameters,
+    BenchParameters,
+    ConfigError,
+)
 from benchmark.logs import LogParser, ParseError
 from benchmark.utils import Print, BenchError, PathMaker
 
 
 class LocalBench:
-    BASE_PORT = 3000
+    BASE_PORT = 4000
 
     def __init__(self, bench_parameters_dict, node_parameters_dict):
         try:
             self.bench_parameters = BenchParameters(bench_parameters_dict)
             self.node_parameters = NodeParameters(node_parameters_dict)
         except ConfigError as e:
-            raise BenchError('Invalid nodes or bench parameters', e)
+            raise BenchError("Invalid nodes or bench parameters", e)
 
     def __getattr__(self, attr):
         return getattr(self.bench_parameters, attr)
 
     def _background_run(self, command, log_file):
         name = splitext(basename(log_file))[0]
-        cmd = f'{command} 2> {log_file}'
-        subprocess.run(['tmux', 'new', '-d', '-s', name, cmd], check=True)
+        cmd = f"{command} 2> {log_file}"
+        subprocess.run(["tmux", "new", "-d", "-s", name, cmd], check=True)
 
     def _kill_nodes(self):
         try:
             cmd = CommandMaker.kill().split()
             subprocess.run(cmd, stderr=subprocess.DEVNULL)
         except subprocess.SubprocessError as e:
-            raise BenchError('Failed to kill testbed', e)
+            raise BenchError("Failed to kill testbed", e)
 
     def run(self, debug=False):
         assert isinstance(debug, bool)
-        Print.heading('Starting local benchmark')
+        Print.heading("Starting local benchmark")
 
         # Kill any previous testbed.
         self._kill_nodes()
 
         try:
-            Print.info('Setting up testbed...')
+            Print.info("Setting up testbed...")
             nodes, rate = self.nodes[0], self.rate[0]
 
             # Cleanup all files.
-            cmd = f'{CommandMaker.clean_logs()} ; {CommandMaker.cleanup()}'
+            cmd = f"{CommandMaker.clean_logs()} ; {CommandMaker.cleanup()}"
             subprocess.run([cmd], shell=True, stderr=subprocess.DEVNULL)
             sleep(0.5)  # Removing the store may take time.
 
@@ -77,12 +83,12 @@ class LocalBench:
             workers_addresses = committee.workers_addresses(self.faults)
             rate_share = ceil(rate / committee.workers())
             for i, addresses in enumerate(workers_addresses):
-                for (id, address) in addresses:
+                for id, address in addresses:
                     cmd = CommandMaker.run_client(
                         address,
                         self.tx_size,
                         rate_share,
-                        [x for y in workers_addresses for _, x in y]
+                        [x for y in workers_addresses for _, x in y],
                     )
                     log_file = PathMaker.client_log_file(i, id)
                     self._background_run(cmd, log_file)
@@ -94,34 +100,34 @@ class LocalBench:
                     PathMaker.committee_file(),
                     PathMaker.db_path(i),
                     PathMaker.parameters_file(),
-                    debug=debug
+                    debug=debug,
                 )
                 log_file = PathMaker.primary_log_file(i)
                 self._background_run(cmd, log_file)
 
             # Run the workers (except the faulty ones).
             for i, addresses in enumerate(workers_addresses):
-                for (id, address) in addresses:
+                for id, address in addresses:
                     cmd = CommandMaker.run_worker(
                         PathMaker.key_file(i),
                         PathMaker.committee_file(),
                         PathMaker.db_path(i, id),
                         PathMaker.parameters_file(),
                         id,  # The worker's id.
-                        debug=debug
+                        debug=debug,
                     )
                     log_file = PathMaker.worker_log_file(i, id)
                     self._background_run(cmd, log_file)
 
             # Wait for all transactions to be processed.
-            Print.info(f'Running benchmark ({self.duration} sec)...')
+            Print.info(f"Running benchmark ({self.duration} sec)...")
             sleep(self.duration)
             self._kill_nodes()
 
             # Parse logs and return the parser.
-            Print.info('Parsing logs...')
+            Print.info("Parsing logs...")
             return LogParser.process(PathMaker.logs_path(), faults=self.faults)
 
         except (subprocess.SubprocessError, ParseError) as e:
             self._kill_nodes()
-            raise BenchError('Failed to run benchmark', e)
+            raise BenchError("Failed to run benchmark", e)

--- a/benchmark/benchmark/logs.py
+++ b/benchmark/benchmark/logs.py
@@ -23,19 +23,18 @@ class LogParser:
         self.faults = faults
         if isinstance(faults, int):
             self.committee_size = len(primaries) + int(faults)
-            self.workers =  len(workers) // len(primaries)
+            self.workers = len(workers) // len(primaries)
         else:
-            self.committee_size = '?'
-            self.workers = '?'
+            self.committee_size = "?"
+            self.workers = "?"
 
         # Parse the clients logs.
         try:
             with Pool() as p:
                 results = p.map(self._parse_clients, clients)
         except (ValueError, IndexError, AttributeError) as e:
-            raise ParseError(f'Failed to parse clients\' logs: {e}')
-        self.size, self.rate, self.start, misses, self.sent_samples \
-            = zip(*results)
+            raise ParseError(f"Failed to parse clients' logs: {e}")
+        self.size, self.rate, self.start, misses, self.sent_samples = zip(*results)
         self.misses = sum(misses)
 
         # Parse the primaries logs.
@@ -43,7 +42,7 @@ class LogParser:
             with Pool() as p:
                 results = p.map(self._parse_primaries, primaries)
         except (ValueError, IndexError, AttributeError) as e:
-            raise ParseError(f'Failed to parse nodes\' logs: {e}')
+            raise ParseError(f"Failed to parse nodes' logs: {e}")
         proposals, commits, self.configs, primary_ips = zip(*results)
         self.proposals = self._merge_results([x.items() for x in proposals])
         self.commits = self._merge_results([x.items() for x in commits])
@@ -53,20 +52,16 @@ class LogParser:
             with Pool() as p:
                 results = p.map(self._parse_workers, workers)
         except (ValueError, IndexError, AttributeError) as e:
-            raise ParseError(f'Failed to parse workers\' logs: {e}')
+            raise ParseError(f"Failed to parse workers' logs: {e}")
         sizes, self.received_samples, workers_ips = zip(*results)
-        self.sizes = {
-            k: v for x in sizes for k, v in x.items() if k in self.commits
-        }
+        self.sizes = {k: v for x in sizes for k, v in x.items() if k in self.commits}
 
         # Determine whether the primary and the workers are collocated.
         self.collocate = set(primary_ips) == set(workers_ips)
 
         # Check whether clients missed their target rate.
         if self.misses != 0:
-            Print.warn(
-                f'Clients missed their target rate {self.misses:,} time(s)'
-            )
+            Print.warn(f"Clients missed their target rate {self.misses:,} time(s)")
 
     def _merge_results(self, input):
         # Keep the earliest timestamp.
@@ -78,78 +73,64 @@ class LogParser:
         return merged
 
     def _parse_clients(self, log):
-        if search(r'Error', log) is not None:
-            raise ParseError('Client(s) panicked')
+        if search(r"Error", log) is not None:
+            raise ParseError("Client(s) panicked")
 
-        size = int(search(r'Transactions size: (\d+)', log).group(1))
-        rate = int(search(r'Transactions rate: (\d+)', log).group(1))
+        size = int(search(r"Transactions size: (\d+)", log).group(1))
+        rate = int(search(r"Transactions rate: (\d+)", log).group(1))
 
-        tmp = search(r'\[(.*Z) .* Start ', log).group(1)
+        tmp = search(r"\[(.*Z) .* Start ", log).group(1)
         start = self._to_posix(tmp)
 
-        misses = len(findall(r'rate too high', log))
+        misses = len(findall(r"rate too high", log))
 
-        tmp = findall(r'\[(.*Z) .* sample transaction (\d+)', log)
+        tmp = findall(r"\[(.*Z) .* sample transaction (\d+)", log)
         samples = {int(s): self._to_posix(t) for t, s in tmp}
 
         return size, rate, start, misses, samples
 
     def _parse_primaries(self, log):
-        if search(r'(?:panicked|Error)', log) is not None:
-            raise ParseError('Primary(s) panicked')
+        if search(r"(?:panicked|Error)", log) is not None:
+            raise ParseError("Primary(s) panicked")
 
-        tmp = findall(r'\[(.*Z) .* Created B\d+\([^ ]+\) -> ([^ ]+=)', log)
+        tmp = findall(r"\[(.*Z) .* Created B\d+\([^ ]+\) -> ([^ ]+=)", log)
         tmp = [(d, self._to_posix(t)) for t, d in tmp]
         proposals = self._merge_results([tmp])
 
-        tmp = findall(r'\[(.*Z) .* Committed B\d+\([^ ]+\) -> ([^ ]+=)', log)
+        tmp = findall(r"\[(.*Z) .* Committed B\d+\([^ ]+\) -> ([^ ]+=)", log)
         tmp = [(d, self._to_posix(t)) for t, d in tmp]
         commits = self._merge_results([tmp])
 
         configs = {
-            'header_size': int(
-                search(r'Header size .* (\d+)', log).group(1)
-            ),
-            'max_header_delay': int(
-                search(r'Max header delay .* (\d+)', log).group(1)
-            ),
-            'gc_depth': int(
-                search(r'Garbage collection depth .* (\d+)', log).group(1)
-            ),
-            'sync_retry_delay': int(
-                search(r'Sync retry delay .* (\d+)', log).group(1)
-            ),
-            'sync_retry_nodes': int(
-                search(r'Sync retry nodes .* (\d+)', log).group(1)
-            ),
-            'batch_size': int(
-                search(r'Batch size .* (\d+)', log).group(1)
-            ),
-            'max_batch_delay': int(
-                search(r'Max batch delay .* (\d+)', log).group(1)
-            ),
+            "header_size": int(search(r"Header size .* (\d+)", log).group(1)),
+            "max_header_delay": int(search(r"Max header delay .* (\d+)", log).group(1)),
+            "gc_depth": int(search(r"Garbage collection depth .* (\d+)", log).group(1)),
+            "sync_retry_delay": int(search(r"Sync retry delay .* (\d+)", log).group(1)),
+            "sync_retry_nodes": int(search(r"Sync retry nodes .* (\d+)", log).group(1)),
+            "batch_size": int(search(r"Batch size .* (\d+)", log).group(1)),
+            "max_batch_delay": int(search(r"Max batch delay .* (\d+)", log).group(1)),
         }
 
-        ip = search(r'booted on (\d+.\d+.\d+.\d+)', log).group(1)
-        
+        ip = search(r"booted on (\d+.\d+.\d+.\d+)", log).group(1)
+
         return proposals, commits, configs, ip
 
     def _parse_workers(self, log):
-        if search(r'(?:panic|Error)', log) is not None:
-            raise ParseError('Worker(s) panicked')
+        if search(r"(?:panic|Error)", log) is not None:
+            raise ParseError("Worker(s) panicked")
 
-        tmp = findall(r'Batch ([^ ]+) contains (\d+) B', log)
+        tmp = findall(r"Batch ([^ ]+) contains (\d+) B", log)
         sizes = {d: int(s) for d, s in tmp}
 
-        tmp = findall(r'Batch ([^ ]+) contains sample tx (\d+)', log)
+        tmp = findall(r"Batch ([^ ]+) contains sample tx (\d+)", log)
         samples = {int(s): d for d, s in tmp}
 
-        ip = search(r'booted on (\d+.\d+.\d+.\d+)', log).group(1)
+        ip = search(r"booted on (\d+.\d+.\d+.\d+)", log).group(1)
 
         return sizes, samples, ip
 
     def _to_posix(self, string):
-        x = datetime.fromisoformat(string.replace('Z', '+00:00'))
+        x = datetime.fromisoformat(string.replace("Z", "+00:00"))
         return datetime.timestamp(x)
 
     def _consensus_throughput(self):
@@ -184,17 +165,17 @@ class LogParser:
                     assert tx_id in sent  # We receive txs that we sent.
                     start = sent[tx_id]
                     end = self.commits[batch_id]
-                    latency += [end-start]
+                    latency += [end - start]
         return mean(latency) if latency else 0
 
     def result(self):
-        header_size = self.configs[0]['header_size']
-        max_header_delay = self.configs[0]['max_header_delay']
-        gc_depth = self.configs[0]['gc_depth']
-        sync_retry_delay = self.configs[0]['sync_retry_delay']
-        sync_retry_nodes = self.configs[0]['sync_retry_nodes']
-        batch_size = self.configs[0]['batch_size']
-        max_batch_delay = self.configs[0]['max_batch_delay']
+        header_size = self.configs[0]["header_size"]
+        max_header_delay = self.configs[0]["max_header_delay"]
+        gc_depth = self.configs[0]["gc_depth"]
+        sync_retry_delay = self.configs[0]["sync_retry_delay"]
+        sync_retry_nodes = self.configs[0]["sync_retry_nodes"]
+        batch_size = self.configs[0]["batch_size"]
+        max_batch_delay = self.configs[0]["max_batch_delay"]
 
         consensus_latency = self._consensus_latency() * 1_000
         consensus_tps, consensus_bps, _ = self._consensus_throughput()
@@ -202,41 +183,41 @@ class LogParser:
         end_to_end_latency = self._end_to_end_latency() * 1_000
 
         return (
-            '\n'
-            '-----------------------------------------\n'
-            ' SUMMARY:\n'
-            '-----------------------------------------\n'
-            ' + CONFIG:\n'
-            f' Faults: {self.faults} node(s)\n'
-            f' Committee size: {self.committee_size} node(s)\n'
-            f' Worker(s) per node: {self.workers} worker(s)\n'
-            f' Collocate primary and workers: {self.collocate}\n'
-            f' Input rate: {sum(self.rate):,} tx/s\n'
-            f' Transaction size: {self.size[0]:,} B\n'
-            f' Execution time: {round(duration):,} s\n'
-            '\n'
-            f' Header size: {header_size:,} B\n'
-            f' Max header delay: {max_header_delay:,} ms\n'
-            f' GC depth: {gc_depth:,} round(s)\n'
-            f' Sync retry delay: {sync_retry_delay:,} ms\n'
-            f' Sync retry nodes: {sync_retry_nodes:,} node(s)\n'
-            f' batch size: {batch_size:,} B\n'
-            f' Max batch delay: {max_batch_delay:,} ms\n'
-            '\n'
-            ' + RESULTS:\n'
-            f' Consensus TPS: {round(consensus_tps):,} tx/s\n'
-            f' Consensus BPS: {round(consensus_bps):,} B/s\n'
-            f' Consensus latency: {round(consensus_latency):,} ms\n'
-            '\n'
-            f' End-to-end TPS: {round(end_to_end_tps):,} tx/s\n'
-            f' End-to-end BPS: {round(end_to_end_bps):,} B/s\n'
-            f' End-to-end latency: {round(end_to_end_latency):,} ms\n'
-            '-----------------------------------------\n'
+            "\n"
+            "-----------------------------------------\n"
+            " SUMMARY:\n"
+            "-----------------------------------------\n"
+            " + CONFIG:\n"
+            f" Faults: {self.faults} node(s)\n"
+            f" Committee size: {self.committee_size} node(s)\n"
+            f" Worker(s) per node: {self.workers} worker(s)\n"
+            f" Collocate primary and workers: {self.collocate}\n"
+            f" Input rate: {sum(self.rate):,} tx/s\n"
+            f" Transaction size: {self.size[0]:,} B\n"
+            f" Execution time: {round(duration):,} s\n"
+            "\n"
+            f" Header size: {header_size:,} B\n"
+            f" Max header delay: {max_header_delay:,} ms\n"
+            f" GC depth: {gc_depth:,} round(s)\n"
+            f" Sync retry delay: {sync_retry_delay:,} ms\n"
+            f" Sync retry nodes: {sync_retry_nodes:,} node(s)\n"
+            f" batch size: {batch_size:,} B\n"
+            f" Max batch delay: {max_batch_delay:,} ms\n"
+            "\n"
+            " + RESULTS:\n"
+            f" Consensus TPS: {round(consensus_tps):,} tx/s\n"
+            f" Consensus BPS: {round(consensus_bps):,} B/s\n"
+            f" Consensus latency: {round(consensus_latency):,} ms\n"
+            "\n"
+            f" End-to-end TPS: {round(end_to_end_tps):,} tx/s\n"
+            f" End-to-end BPS: {round(end_to_end_bps):,} B/s\n"
+            f" End-to-end latency: {round(end_to_end_latency):,} ms\n"
+            "-----------------------------------------\n"
         )
 
     def print(self, filename):
         assert isinstance(filename, str)
-        with open(filename, 'a') as f:
+        with open(filename, "a") as f:
             f.write(self.result())
 
     @classmethod
@@ -244,16 +225,16 @@ class LogParser:
         assert isinstance(directory, str)
 
         clients = []
-        for filename in sorted(glob(join(directory, 'client-*.log'))):
-            with open(filename, 'r') as f:
+        for filename in sorted(glob(join(directory, "client-*.log"))):
+            with open(filename, "r") as f:
                 clients += [f.read()]
         primaries = []
-        for filename in sorted(glob(join(directory, 'primary-*.log'))):
-            with open(filename, 'r') as f:
+        for filename in sorted(glob(join(directory, "primary-*.log"))):
+            with open(filename, "r") as f:
                 primaries += [f.read()]
         workers = []
-        for filename in sorted(glob(join(directory, 'worker-*.log'))):
-            with open(filename, 'r') as f:
+        for filename in sorted(glob(join(directory, "worker-*.log"))):
+            with open(filename, "r") as f:
                 workers += [f.read()]
 
         return cls(clients, primaries, workers, faults=faults)

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-rocksdb = "0.16.0"
+rocksdb = "0.22.0"
 tokio = { version = "1.5.0", features = ["sync", "macros", "rt"] }


### PR DESCRIPTION
This helps third party tools to analyse performance without downloading client logs.

Also:
- Change the default port for local benchmarks to port 4000 (because port 3000 was conflicting with too many services)
- Update the version of rocks db to 0.22 to make it compatible with the latest rust toolchain